### PR TITLE
Fix tool docs publishing for large payloads

### DIFF
--- a/.agentics/tool/pks/opencode/opencode.md
+++ b/.agentics/tool/pks/opencode/opencode.md
@@ -20,6 +20,32 @@ examples:
 
 The default model is **GLM 5.2** (`glm-5.2`) on Scaleway. Run `pks opencode` with no arguments and you are in. Pass `--model kimi-k3` and you are on **Kimi K3** via Moonshot instead — same command, no extra flags.
 
+## Run pks your way
+
+Use an installed `pks` command, run the NuGet tool directly with .NET 10, or run the npm package without installing it globally:
+
+```commandtabs
+{
+  "tabs": [
+    {
+      "label": "pks",
+      "command": "dotnet tool install --global pks-cli\npks scaleway init\npks opencode --model glm-5.2",
+      "hint": "Installs the permanent pks command as a .NET global tool"
+    },
+    {
+      "label": "dnx",
+      "command": "dotnet dnx pks-cli --yes -- scaleway init\ndotnet dnx pks-cli --yes -- opencode --model glm-5.2",
+      "hint": "Runs directly from NuGet · requires .NET 10"
+    },
+    {
+      "label": "npx",
+      "command": "npx @pks-cli/cli scaleway init\nnpx @pks-cli/cli opencode --model glm-5.2",
+      "hint": "Runs directly from npm · requires Node.js"
+    }
+  ]
+}
+```
+
 ## The model picks the provider
 
 You never tell `pks opencode` where a model lives. pks keeps a small provider catalog, and the model id resolves it:

--- a/.github/actions/publish-tool-docs/action.yml
+++ b/.github/actions/publish-tool-docs/action.yml
@@ -88,18 +88,17 @@ runs:
         fi
 
         # Build the full payload
-        PAYLOAD=$(jq -n \
+        PAYLOAD=$(printf '%s' "$FILES_JSON" | jq -c \
           --arg component "$COMPONENT" \
           --arg version "$VERSION" \
-          --argjson files "$FILES_JSON" \
-          '{component: $component, version: $version, files: $files}')
+          '{component: $component, version: $version, files: .}')
 
         # POST to the API (trusted publishing: OIDC repo + component must match a product)
-        HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+        HTTP_RESPONSE=$(printf '%s' "$PAYLOAD" | curl -s -w "\n%{http_code}" \
           -X POST \
           -H "Authorization: Bearer ${OIDC}" \
           -H "Content-Type: application/json" \
-          -d "$PAYLOAD" \
+          --data-binary @- \
           "${SERVER}/api/tools/docs")
 
         HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -1)


### PR DESCRIPTION
## What changed
- stream the generated docs JSON payload to curl over stdin
- avoid expanding the full files array as a jq command-line argument
- document pks, dnx and npx launch methods on the OpenCode tool page

## Why
The v6.21.0 docs job attempted to pass roughly 1.2 MB as command-line arguments and exited with code 126, leaving production on the partial v6.20.1 docs tree.

## Validation
- assembled and parsed the complete 174-file payload locally
- verified a 1,255,643-byte JSON request
- diff and YAML validation